### PR TITLE
Use HH (24-hour clock) instead of hh (12-hour clock)

### DIFF
--- a/protocol.js
+++ b/protocol.js
@@ -57,7 +57,7 @@ exports.parserCQ = function(message) {
 			reportType:         "CQ",
 			reportId:           x[01],
 			gpsDateTime:        null,
-			reportDateTime:     dateFormat(reportDateTime, "yyyy-mm-dd hh:MM:ss"),
+			reportDateTime:     dateFormat(reportDateTime, "yyyy-mm-dd HH:MM:ss"),
 			latitude:           x[08]/100000,
 			longitude:          x[09]/100000, 
 			speed:              parseInt(x[10]),


### PR DESCRIPTION
Original source uses 12-hour clock ("hh") in date format string, making reports before/after midday indistinguishable. Changing date format string to 24-hour clock ("HH") solves the issue.